### PR TITLE
Synthetic lowmass bugfix pr

### DIFF
--- a/cosmodc2/synthetic_subhalos/__init__.py
+++ b/cosmodc2/synthetic_subhalos/__init__.py
@@ -1,2 +1,3 @@
 from .extend_subhalo_mpeak_range import *
 from .synthetic_cluster_satellites import *
+from .synthetic_lowmass_subhalos import *

--- a/cosmodc2/synthetic_subhalos/synthetic_lowmass_subhalos.py
+++ b/cosmodc2/synthetic_subhalos/synthetic_lowmass_subhalos.py
@@ -1,0 +1,40 @@
+"""
+"""
+import numpy as np
+from astropy.utils.misc import NumpyRNGContext
+default_desired_logm_completeness = 9.75
+
+
+__all__ = ('synthetic_logmpeak',)
+
+
+def synthetic_logmpeak(mpeak_orig, desired_logm_completeness=default_desired_logm_completeness,
+            nout_max=np.inf, c0=5.5, c1=-0.15,
+            lowm_fit=11.5, highm_fit=12.25, dlogm_fit=0.1, return_fit=False, seed=43):
+    """
+    """
+    logmbins_fit = np.arange(lowm_fit, highm_fit+dlogm_fit, dlogm_fit)
+    logmmids_fit = 0.5*(logmbins_fit[:-1] + logmbins_fit[1:])
+
+    logmpeak_orig = np.log10(mpeak_orig)
+    counts_fit, __ = np.histogram(logmpeak_orig, bins=logmbins_fit)
+
+    zero_mask = counts_fit > 0.
+    if np.count_nonzero(zero_mask) > 3:
+        c1, c0 = np.polyfit(logmmids_fit[zero_mask], np.log10(counts_fit[zero_mask]), deg=1)
+
+    logmbins_extrap = np.arange(desired_logm_completeness-dlogm_fit, highm_fit+dlogm_fit, dlogm_fit)
+    logmmids_extrap = 0.5*(logmbins_extrap[:-1] + logmbins_extrap[1:])
+    logcounts_extrap = c0 + c1*logmmids_extrap
+    model_counts_extrap = np.array(10**logcounts_extrap).astype(int)
+    actual_counts_extrap, __ = np.histogram(logmpeak_orig, bins=logmbins_extrap)
+    delta_counts_extrap = np.maximum(model_counts_extrap - actual_counts_extrap, 0)
+    delta_counts_cumprob = np.cumsum(delta_counts_extrap)/float(delta_counts_extrap.sum()+1)
+
+    npts_out = int(min(nout_max, delta_counts_extrap.sum()))
+    with NumpyRNGContext(seed):
+        uran = np.random.rand(npts_out)
+    mc_logm = np.interp(uran, delta_counts_cumprob, logmmids_extrap)
+    outmask = mc_logm > desired_logm_completeness
+    return mc_logm[outmask]
+

--- a/cosmodc2/synthetic_subhalos/tests/test_lowmass.py
+++ b/cosmodc2/synthetic_subhalos/tests/test_lowmass.py
@@ -1,0 +1,25 @@
+"""
+"""
+import numpy as np
+from scipy.stats import powerlaw
+
+from ..synthetic_lowmass_subhalos import synthetic_logmpeak
+
+
+def test1():
+
+    _norig = int(2e5)
+    index = 2.
+    lowm_orig, highm_orig = 10., 15.
+    orig_width = highm_orig - lowm_orig
+    _logmpeak_orig = (orig_width*(1.-powerlaw.rvs(index, size=_norig)) + lowm_orig)
+    prob_reject = np.interp(_logmpeak_orig, [10, 10.75], [0.95, 0.])
+    mask_reject = np.random.rand(_norig) < prob_reject
+
+    logmpeak_orig = _logmpeak_orig[~mask_reject]
+    mpeak_orig = 10.**logmpeak_orig
+
+    desired_logm_completeness = 9.
+    fake_logm = synthetic_logmpeak(mpeak_orig, desired_logm_completeness)
+    assert np.any(fake_logm < logmpeak_orig.min())
+    assert np.all(fake_logm >= desired_logm_completeness)

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -208,7 +208,6 @@ def write_umachine_healpix_mock_to_disk(
 
         #  Assign colors to synthetic low-mass galaxies
         synthetic_upid = np.zeros_like(mpeak_synthetic_snapshot).astype(int) - 1
-        synthetic_halo_mass = np.zeros_like(mpeak_synthetic_snapshot) + 1e12
         synthetic_redshift = np.zeros_like(mpeak_synthetic_snapshot) + redshift
         with NumpyRNGContext(seed):
             synthetic_sfr_percentile = np.random.uniform(0, 1, len(synthetic_upid))
@@ -220,13 +219,15 @@ def write_umachine_healpix_mock_to_disk(
 
         #  Now appropriately downsample the synthetic galaxies
         #  according to the size of the healpixel
-        num_selected_galaxies = len(source_galaxy_indx)
-        frac_gals_in_healpix = num_selected_galaxies/float(len(mock))
-        num_synthetic_galaxies = int(frac_gals_in_healpix*len(mock))
-        synthetic_indices = np.arange(0, mpeak_synthetic_snapshot).astype(int)
+        num_galsampled_into_healpix = len(source_galaxy_indx)
+        frac_gals_in_healpix = num_galsampled_into_healpix/float(len(mock))
+        num_synthetic_gals_in_snapshot = len(mpeak_synthetic_snapshot)
+        num_synthetic_in_healpix = int(frac_gals_in_healpix*num_synthetic_gals_in_snapshot)
+        num_selected_synthetic = int(num_synthetic_in_healpix*num_synthetic_gal_ratio)
+        synthetic_indices = np.arange(0, num_synthetic_gals_in_snapshot).astype(int)
         with NumpyRNGContext(seed):
             selected_synthetic_indices = np.random.choice(
-                synthetic_indices, size=num_synthetic_galaxies, replace=False)
+                synthetic_indices, size=num_selected_synthetic, replace=False)
         mpeak_synthetic = mpeak_synthetic_snapshot[selected_synthetic_indices]
         mstar_synthetic = mstar_synthetic_snapshot[selected_synthetic_indices]
         magr_synthetic = magr_synthetic_snapshot[selected_synthetic_indices]

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -8,16 +8,18 @@ import re
 from time import time
 from astropy.table import Table, vstack
 from astropy.cosmology import FlatLambdaCDM
+from astropy.utils.misc import NumpyRNGContext
 from cosmodc2.sdss_colors import assign_restframe_sdss_gri
 from cosmodc2.stellar_mass_remapping import remap_stellar_mass_in_snapshot
 from galsampler import halo_bin_indices, source_halo_index_selection
 from galsampler.cython_kernels import galaxy_selection_kernel
 from halotools.utils import crossmatch
 
-from cosmodc2.synthetic_subhalos import model_extended_mpeak, map_mstar_onto_lowmass_extension
+from cosmodc2.synthetic_subhalos import map_mstar_onto_lowmass_extension
 from cosmodc2.synthetic_subhalos import create_synthetic_lowmass_mock_with_centrals
 from cosmodc2.synthetic_subhalos import create_synthetic_lowmass_mock_with_satellites
 from cosmodc2.synthetic_subhalos import create_synthetic_cluster_satellites
+from cosmodc2.synthetic_subhalos import synthetic_logmpeak
 
 fof_halo_mass = 'fof_halo_mass'
 mass = 'mass'
@@ -93,7 +95,7 @@ def write_umachine_healpix_mock_to_disk(
 
     cutout_number = file_ids[-1]
     z_range_id = file_ids[0]
-    galaxy_id_offset = int(cutout_number*cutout_id_offset_galaxy + z_offsets[z_range_id]) 
+    galaxy_id_offset = int(cutout_number*cutout_id_offset_galaxy + z_offsets[z_range_id])
     halo_id_cutout_offset = int(cutout_number*cutout_id_offset_halo)
 
     #  determine seed from output filename
@@ -169,15 +171,9 @@ def write_umachine_healpix_mock_to_disk(
         #  Correct stellar mass for low-mass subhalos and create synthetic mpeak
         ########################################################################
         print("...correcting low mass mpeak and assigning synthetic mpeak values")
-        num_selected_galaxies = len(source_galaxy_indx)
-        corrected_mpeak, mpeak_synthetic = model_extended_mpeak(
-                mock['mpeak'], num_selected_galaxies, synthetic_halo_minimum_mass, Lbox=Lbox)
-        mock['mpeak'] = corrected_mpeak
-
-        #  Select (num_synthetic_gal_ratio*num_selected_galaxies) synthetic galaxies to keep file size down
-        num_synthetic_galaxies = int(num_synthetic_gal_ratio*num_selected_galaxies)
-        mpeak_synthetic = np.random.choice(mpeak_synthetic, size=num_synthetic_galaxies, replace=False)
-        print('...assembling {} synthetic galaxies'.format(num_synthetic_galaxies))
+        #  First generate the appropriate number of synthetic galaxies for the snapshot
+        mpeak_synthetic_snapshot = 10**synthetic_logmpeak(mock['mpeak'], seed=seed)
+        print('...assembling {} synthetic galaxies'.format(len(mpeak_synthetic_snapshot)))
 
         ########################################################################
         #  Assign stellar mass, using Outer Rim halo mass for very massive halos
@@ -206,9 +202,42 @@ def write_umachine_healpix_mock_to_disk(
 
         #  Add call to map_mstar_onto_lowmass_extension function after pre-determining low-mass slope
         print("...re-assigning low-mass mstar values")
-        new_mstar_real, mstar_synthetic = map_mstar_onto_lowmass_extension(
-            mock['mpeak'], mock['obs_sm'], mpeak_synthetic)
+        new_mstar_real, mstar_synthetic_snapshot = map_mstar_onto_lowmass_extension(
+            mock['mpeak'], mock['obs_sm'], mpeak_synthetic_snapshot)
         mock['obs_sm'] = new_mstar_real
+
+        #  Assign colors to synthetic low-mass galaxies
+        synthetic_upid = np.zeros_like(mpeak_synthetic_snapshot).astype(int) - 1
+        synthetic_halo_mass = np.zeros_like(mpeak_synthetic_snapshot) + 1e12
+        synthetic_redshift = np.zeros_like(mpeak_synthetic_snapshot) + redshift
+        with NumpyRNGContext(seed):
+            synthetic_sfr_percentile = np.random.uniform(0, 1, len(synthetic_upid))
+        _result = assign_restframe_sdss_gri(
+            synthetic_upid, mstar_synthetic_snapshot, synthetic_sfr_percentile,
+            mpeak_synthetic_snapshot, synthetic_redshift, seed=seed)
+        (magr_synthetic_snapshot, gr_synthetic_snapshot, ri_synthetic_snapshot,
+            is_red_gr_synthetic_snapshot, is_red_ri_synthetic_snapshot) = _result
+
+        #  Now appropriately downsample the synthetic galaxies
+        #  according to the size of the healpixel
+        num_selected_galaxies = len(source_galaxy_indx)
+        frac_gals_in_healpix = num_selected_galaxies/float(len(mock))
+        num_synthetic_galaxies = int(frac_gals_in_healpix*len(mock))
+        synthetic_indices = np.arange(0, mpeak_synthetic_snapshot).astype(int)
+        with NumpyRNGContext(seed):
+            selected_synthetic_indices = np.random.choice(
+                synthetic_indices, size=num_synthetic_galaxies, replace=False)
+        mpeak_synthetic = mpeak_synthetic_snapshot[selected_synthetic_indices]
+        mstar_synthetic = mstar_synthetic_snapshot[selected_synthetic_indices]
+        magr_synthetic = magr_synthetic_snapshot[selected_synthetic_indices]
+        gr_synthetic = gr_synthetic_snapshot[selected_synthetic_indices]
+        ri_synthetic = ri_synthetic_snapshot[selected_synthetic_indices]
+        is_red_gr_synthetic = is_red_gr_synthetic_snapshot[selected_synthetic_indices]
+        is_red_ri_synthetic = is_red_ri_synthetic_snapshot[selected_synthetic_indices]
+        synthetic_dict = dict(
+            mpeak=mpeak_synthetic, obs_sm=mstar_synthetic, restframe_extincted_sdss_abs_magr=magr_synthetic,
+            restframe_extincted_sdss_gr=gr_synthetic, restframe_extincted_sdss_ri=ri_synthetic,
+            is_on_red_sequence_gr=is_red_gr_synthetic, is_on_red_sequence_ri=is_red_ri_synthetic)
 
         #  Assign target halo id and target halo mass to selected galaxies in mock
         mock_target_halo_id = np.zeros(len(mock)) - 1.
@@ -252,7 +281,7 @@ def write_umachine_healpix_mock_to_disk(
         print("...building output snapshot mock for snapshot {}".format(snapshot))
         output_mock[snapshot] = build_output_snapshot_mock(
                 mock, target_halos, source_galaxy_indx, galaxy_id_offset,
-                mpeak_synthetic, mstar_synthetic, Nside_cosmoDC2, cutout_number,
+                synthetic_dict, Nside_cosmoDC2, cutout_number,
                 halo_unique_id=halo_unique_id, redshift_method='halo', use_centrals=use_centrals)
         galaxy_id_offset = galaxy_id_offset + len(output_mock[snapshot]['halo_id'])  #increment offset
 
@@ -321,7 +350,7 @@ def get_astropy_table(table_data, halo_unique_id=0, check=False):
 
 def build_output_snapshot_mock(
             umachine, target_halos, galaxy_indices, galaxy_id_offset,
-            mpeak_synthetic, mstar_synthetic, Nside, cutout_number,
+            synthetic_dict, Nside, cutout_number,
             halo_unique_id=0, redshift_method='galaxy', use_centrals=True):
     """
     Collect the GalSampled snapshot mock into an astropy table
@@ -428,15 +457,15 @@ def build_output_snapshot_mock(
         dc2 = vstack((dc2, fake_cluster_sats))
         print('...time to create {} galaxies in fake_cluster_sats = {:.2f} secs'.format(len(fake_cluster_sats['halo_id']), time()-check_time))
 
-    if len(mpeak_synthetic) > 0:
+    if len(synthetic_dict['mpeak']) > 0:
         check_time = time()
         if use_centrals:
             lowmass_mock = create_synthetic_lowmass_mock_with_centrals(
-                umachine, dc2, mpeak_synthetic, mstar_synthetic, Nside=Nside, cutout_id=cutout_number,
+                umachine, dc2, synthetic_dict, Nside=Nside, cutout_id=cutout_number,
                 H0=H0, OmegaM=OmegaM, halo_id_offset=halo_id_offset, halo_unique_id=halo_unique_id)
         else:
             lowmass_mock = create_synthetic_lowmass_mock_with_satellites(
-                umachine, dc2, mpeak_synthetic, mstar_synthetic,
+                umachine, dc2, synthetic_dict,
                 halo_id_offset=halo_id_offset, halo_unique_id=halo_unique_id)
         if len(lowmass_mock) > 0:
             dc2 = vstack((dc2, lowmass_mock))

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -172,7 +172,8 @@ def write_umachine_healpix_mock_to_disk(
         ########################################################################
         print("...correcting low mass mpeak and assigning synthetic mpeak values")
         #  First generate the appropriate number of synthetic galaxies for the snapshot
-        mpeak_synthetic_snapshot = 10**synthetic_logmpeak(mock['mpeak'], seed=seed)
+        mpeak_synthetic_snapshot = 10**synthetic_logmpeak(
+            mock['mpeak'], seed=seed, desired_logm_completeness=synthetic_halo_minimum_mass)
         print('...assembling {} synthetic galaxies'.format(len(mpeak_synthetic_snapshot)))
 
         ########################################################################


### PR DESCRIPTION
This PR addresses, but does not fully resolve, #14. In short, there were several shortcomings of the synthetic low-mass galaxy feature used to produce cosmoDC2_v0.2, resulting in discreteness effects and unphysical localization of these galaxies in color-magnitude space. This PR should fix all such effects, but in order for #14 to be resolved, there remains the problem of accounting for the healpix masking in the total number of synthetic galaxies created, as discussed with @evevkovacs. 

@evevkovacs - Re: merging. This should be trivial since I merged in your PR #33 before submitting this PR. 