### PR TITLE
Substep refinement

### DIFF
--- a/cosmodc2/sdss_colors/analytical_gr_ri.py
+++ b/cosmodc2/sdss_colors/analytical_gr_ri.py
@@ -77,7 +77,7 @@ def gr_ri_monte_carlo_substeps(magr, sfr_percentile, redshift, nzdivs=6,
     """
     """
     print('.....Check: in gr_ri_monte_carlo_substeps with supplied kwarg seed {}'.format(kwargs.get('seed', -1)))
-
+    print("\n...running gr_ri_monte_carlo_substeps with nzdivs = {0}".format(nzdivs))
     ngals = len(magr)
     sorted_redshift = np.sort(redshift)
     _zbins = sorted_redshift[np.arange(nzdivs+4)*int(ngals/float(nzdivs+4))]

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -43,7 +43,7 @@ def write_umachine_healpix_mock_to_disk(
             redshift_list, commit_hash, synthetic_halo_minimum_mass=9.8, num_synthetic_gal_ratio=1.,
             use_centrals=True, use_substeps_real=True, use_substeps_synthetic=False,
             randomize_redshift_real=True, randomize_redshift_synthetic=True, Lbox=3000.,
-            gaussian_smearing_real_redshifts=0.):
+            gaussian_smearing_real_redshifts=0., nzdivs=6):
     """
     Main driver function used to paint SDSS fluxes onto UniverseMachine,
     GalSample the mock into the lightcone healpix cutout, and write the healpix mock to disk.
@@ -235,7 +235,8 @@ def write_umachine_healpix_mock_to_disk(
             "with synthetic_upid array having {0} elements".format(len(synthetic_upid)))
         _result = assign_restframe_sdss_gri(
             synthetic_upid, mstar_synthetic_snapshot, synthetic_sfr_percentile,
-            mpeak_synthetic_snapshot, synthetic_redshift, seed=seed, use_substeps=use_substeps_synthetic)
+            mpeak_synthetic_snapshot, synthetic_redshift, seed=seed, use_substeps=use_substeps_synthetic,
+            nzdivs=nzdivs)
         (magr_synthetic_snapshot, gr_synthetic_snapshot, ri_synthetic_snapshot,
             is_red_gr_synthetic_snapshot, is_red_ri_synthetic_snapshot) = _result
 
@@ -314,7 +315,8 @@ def write_umachine_healpix_mock_to_disk(
 
         magr, gr_mock, ri_mock, is_red_gr, is_red_ri = assign_restframe_sdss_gri(
             mock['upid'], mock['obs_sm'], mock['sfr_percentile'],
-            mock_remapped_halo_mass, redshift_mock, seed=seed, use_substeps=use_substeps_real)
+            mock_remapped_halo_mass, redshift_mock, seed=seed, use_substeps=use_substeps_real,
+            nzdivs=nzdivs)
         #  check for bad values
         for m_id, m in zip(['magr', 'gr', 'ri'], [magr, gr_mock, ri_mock]):
             num_infinite = np.sum(~np.isfinite(m))

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -299,8 +299,9 @@ def write_umachine_healpix_mock_to_disk(
                 "The functions involved in the color modeling will be passed\n"
                 "noisy versions of the target halo redshifts")
             print(msg.format(gaussian_smearing_real_redshifts))
-            redshift_mock[source_galaxy_indx] = np.random.normal(
-                loc=redshift_mock[source_galaxy_indx], scale=gaussian_smearing_real_redshifts)
+            with NumpyRNGContext(seed):
+                redshift_mock[source_galaxy_indx] = np.random.normal(
+                    loc=redshift_mock[source_galaxy_indx], scale=gaussian_smearing_real_redshifts)
         else:
             msg = ("\ngaussian_smearing_real_redshifts = 0\n"
                 "Using the exact target halo redshifts "


### PR DESCRIPTION
This PR adds two new switches for the primary driver function of the mock making, `write_umachine_healpix_mock_to_disk`. 

```
1. nzdivs=6 
2. gaussian_smearing_real_redshifts=0. 

```
The `nzdivs` argument defines the number of substeps. The `gaussian_smearing_real_redshifts` determines how much noise to add to the target halo redshifts before modeling the colors of GalSampler-selected galaxies. The current default settings are in accord with the most recent run of the model on Cooley by @evevkovacs. But changes to these keyword arguments now propagate down through to their operative place in the pipeline. Additional print statements have been included to explicitly verify that the component functions have been called with the intended argument values. 