### PR TITLE
Remodel boost to cluster mass-richness relation

### DIFF
--- a/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
+++ b/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
@@ -98,12 +98,12 @@ def model_synthetic_cluster_satellites(mock, Lbox=256.,
         #  For every synthetic galaxy, calculate the mass, redshift, position, and velocity of the host halo
         synthetic_hostmass = np.repeat(host_mass, synthetic_richness)
         synthetic_redshift = np.repeat(host_redshift, synthetic_richness)
-        synthetic_target_halo_x = np.repeat(host_mass, host_x)
-        synthetic_target_halo_y = np.repeat(host_mass, host_y)
-        synthetic_target_halo_z = np.repeat(host_mass, host_z)
-        synthetic_target_halo_vx = np.repeat(host_mass, host_vx)
-        synthetic_target_halo_vy = np.repeat(host_mass, host_vy)
-        synthetic_target_halo_vz = np.repeat(host_mass, host_vz)
+        synthetic_target_halo_x = np.repeat(host_x, synthetic_richness)
+        synthetic_target_halo_y = np.repeat(host_y, synthetic_richness)
+        synthetic_target_halo_z = np.repeat(host_z, synthetic_richness)
+        synthetic_target_halo_vx = np.repeat(host_vx, synthetic_richness)
+        synthetic_target_halo_vy = np.repeat(host_vy, synthetic_richness)
+        synthetic_target_halo_vz = np.repeat(host_vz, synthetic_richness)
 
         #  Use Halotools to generate halo-centric positions and velocities according to NFW
         nfw = NFWPhaseSpace()

--- a/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
+++ b/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
@@ -2,6 +2,10 @@ import numpy as np
 from scipy.spatial import cKDTree
 from astropy.table import Table
 from halotools.empirical_models import NFWPhaseSpace
+from scipy.stats import powerlaw
+from ..sdss_colors.sigmoid_magr_model import magr_monte_carlo
+from ..sdss_colors.sigmoid_g_minus_r import red_sequence_peak_gr
+from ..sdss_colors.sigmoid_r_minus_i import red_sequence_peak_ri
 
 
 __all__ = ('nearby_hostmass_selection_indices', 'calculate_synthetic_richness',
@@ -64,11 +68,139 @@ def calculate_synthetic_richness(halo_richness, logmhalo, logmhalo_source,
     return np.array(halo_richness*boost_factor, dtype=int)
 
 
+def model_synthetic_cluster_satellites(mock, Lbox=256.,
+        cluster_satboost_logm_table=[13.5, 13.75, 14],
+        cluster_satboost_table=[0., 0.15, 0.2], **kwargs):
+    """
+    """
+    #  Calculate the mass and richness of every target halo
+    host_halo_id, idx, counts = np.unique(
+        mock['target_halo_id'], return_counts=True, return_index=True)
+    host_mass = mock['target_halo_mass'][idx]
+    host_redshift = mock['target_halo_redshift'][idx]
+    host_x = mock['target_halo_x'][idx]
+    host_y = mock['target_halo_y'][idx]
+    host_z = mock['target_halo_z'][idx]
+    host_vx = mock['target_halo_vx'][idx]
+    host_vy = mock['target_halo_vy'][idx]
+    host_vz = mock['target_halo_vz'][idx]
+    source_halo_mvir = mock['source_halo_mvir'][idx]
+    host_richness = counts
+
+    #  For each target halo, calculate the number of synthetic satellites we need to add
+    synthetic_richness = calculate_synthetic_richness(
+        host_richness, np.log10(host_mass), np.log10(source_halo_mvir),
+        cluster_satboost_logm_table, cluster_satboost_table)
+
+    if np.sum(synthetic_richness) == 0:
+        return Table()
+    else:
+        #  For every synthetic galaxy, calculate the mass, redshift, position, and velocity of the host halo
+        synthetic_hostmass = np.repeat(host_mass, synthetic_richness)
+        synthetic_redshift = np.repeat(host_redshift, synthetic_richness)
+        synthetic_target_halo_x = np.repeat(host_mass, host_x)
+        synthetic_target_halo_y = np.repeat(host_mass, host_y)
+        synthetic_target_halo_z = np.repeat(host_mass, host_z)
+        synthetic_target_halo_vx = np.repeat(host_mass, host_vx)
+        synthetic_target_halo_vy = np.repeat(host_mass, host_vy)
+        synthetic_target_halo_vz = np.repeat(host_mass, host_vz)
+
+        #  Use Halotools to generate halo-centric positions and velocities according to NFW
+        nfw = NFWPhaseSpace()
+        nfw_sats = nfw.mc_generate_nfw_phase_space_points(mass=synthetic_hostmass)
+
+        sats = Table()
+        sats['host_centric_x'] = nfw_sats['x']
+        sats['host_centric_y'] = nfw_sats['y']
+        sats['host_centric_z'] = nfw_sats['z']
+        sats['host_centric_vx'] = nfw_sats['vx']
+        sats['host_centric_vy'] = nfw_sats['vy']
+        sats['host_centric_vz'] = nfw_sats['vz']
+
+        #  Add host-centric pos/vel to target halo pos/vel
+        sats['x'] = synthetic_target_halo_x + nfw_sats['x']
+        sats['y'] = synthetic_target_halo_y + nfw_sats['y']
+        sats['z'] = synthetic_target_halo_z + nfw_sats['z']
+        sats['vx'] = synthetic_target_halo_vx + nfw_sats['vx']
+        sats['vy'] = synthetic_target_halo_vy + nfw_sats['vy']
+        sats['vz'] = synthetic_target_halo_vz + nfw_sats['vz']
+
+        if Lbox > 0.:    # enforce periodicity
+            sats['x'] = np.mod(sats['x'], Lbox)
+            sats['y'] = np.mod(sats['y'], Lbox)
+            sats['z'] = np.mod(sats['z'], Lbox)
+
+        sats['host_halo_mvir'] = synthetic_hostmass
+        sats['upid'] = -1
+
+        #  Assign synthetic subhalo mass according to a power law
+        #  Maximum allowed value of the subhalo mass is the host halo mass
+        #  Power law distribution in subhalo mass spans [11, logMhost]
+        dlogm = np.log10(synthetic_hostmass) - 11.
+        alpha = 2.0  #  power-law slope
+        sats['mpeak'] = 10**(synthetic_hostmass - dlogm*powerlaw.rvs(alpha, size=len(sats)))
+
+        sats['halo_id'] = -1
+        sats['lightcone_id'] = -1
+        sats['um_target_halo_id'] = -1
+        sats['um_target_halo_mass'] = synthetic_hostmass
+        sats['target_halo_redshift'] = synthetic_redshift
+
+        #  Rather than modeling the M*-Mpeak relation, for convenience we'll sample it and add noise
+        #  Note that we will *NOT* derive restframe flux or color this way, only stellar mass and SFR
+        sat_sample_mask = (mock['upid'] != -1) & (mock['is_on_red_sequence_gr'])
+        tree = cKDTree(np.vstack((mock['mpeak'][sat_sample_mask], )).T)
+
+        X2 = np.vstack((sats['mpeak'], )).T
+        nn_distinces, nn_indices = tree.query(X2)
+        nn_indices = np.minimum(len(mock['mpeak'][sat_sample_mask])-1, nn_indices)
+        nn_indices = np.maximum(0, nn_indices)
+        selected_logsm = np.log10(mock['obs_sm'][sat_sample_mask][nn_indices])
+        selected_sfr = mock['obs_sfr'][sat_sample_mask][nn_indices]
+
+        #  Add noise to M* and SFR to prevent repeated values
+        #  Probably unnecessary but doesn't hurt
+        sats['obs_sm'] = 10**np.random.normal(loc=selected_logsm, scale=0.1)
+        sfr_scatter = np.maximum(0.1*selected_sfr, 1.)
+        sats['obs_sfr'] = np.maximum(np.random.normal(loc=selected_sfr, scale=sfr_scatter), 0.)
+
+        sats['_obs_sm_orig_um_snap'] = sats['obs_sm']
+        sats['sfr_percentile'] = mock['sfr_percentile'][sat_sample_mask][nn_indices]
+
+        #  We will only boost the richness of red sequence cluster members
+        sats['is_on_red_sequence_gr'] = True
+        sats['is_on_red_sequence_ri'] = True
+
+        #  Model r-band magnitude just like regular galaxies
+        sats['restframe_extincted_sdss_abs_magr'] = magr_monte_carlo(
+            sats['obs_sm'], sats['upid'], sats['target_halo_redshift'])
+
+        #  Model g-r and r-i color just like regular red sequence galaxies
+        red_sequence_loc_gr = red_sequence_peak_gr(
+            sats['restframe_extincted_sdss_abs_magr'], sats['target_halo_redshift'])
+        red_sequence_loc_ri = red_sequence_peak_ri(
+            sats['restframe_extincted_sdss_abs_magr'], sats['target_halo_redshift'])
+
+        sats['restframe_extincted_sdss_gr'] = np.random.normal(loc=red_sequence_loc_gr, scale=0.05)
+        sats['restframe_extincted_sdss_ri'] = np.random.normal(loc=red_sequence_loc_ri, scale=0.02)
+
+        #  It is important to insure that `sats` has a column for every column of the `dc2` mock
+        #  In case we missed one of the obscure ones, just add it to the table
+        #  Note that this is what we previously did for *ALL* columns
+        satkeys = list(sats.keys())
+        for key in mock.keys():
+            if key not in satkeys:
+                sats[key] = mock[key][sat_sample_mask][nn_indices]
+
+        return sats
+
+
 def create_synthetic_cluster_satellites(mock, Lbox=256.,
         cluster_satboost_logm_table=[13.5, 13.75, 14],
         cluster_satboost_table=[0., 0.15, 0.2], **kwargs):
     """
     """
+    raise ValueError("This function is deprecated. Use `model_synthetic_cluster_satellites` instead.")
     host_halo_id, idx, counts = np.unique(
         mock['target_halo_id'], return_counts=True, return_index=True)
     host_mass = mock['target_halo_mass'][idx]

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -18,7 +18,7 @@ from halotools.utils import crossmatch
 from cosmodc2.synthetic_subhalos import map_mstar_onto_lowmass_extension
 from cosmodc2.synthetic_subhalos import create_synthetic_lowmass_mock_with_centrals
 from cosmodc2.synthetic_subhalos import create_synthetic_lowmass_mock_with_satellites
-from cosmodc2.synthetic_subhalos import create_synthetic_cluster_satellites
+from cosmodc2.synthetic_subhalos import model_synthetic_cluster_satellites
 from cosmodc2.synthetic_subhalos import synthetic_logmpeak
 
 fof_halo_mass = 'fof_halo_mass'
@@ -514,7 +514,7 @@ def build_output_snapshot_mock(
 
     print('...number of galaxies before adding synthetic satellites = {}'.format(len(dc2['halo_id'])))
     print("...generating and stacking any synthetic cluster satellites")
-    fake_cluster_sats = create_synthetic_cluster_satellites(dc2, Lbox=0.) # turn off periodicity
+    fake_cluster_sats = model_synthetic_cluster_satellites(dc2, Lbox=0.) # turn off periodicity
     if len(fake_cluster_sats) > 0:
         check_time = time()
         dc2 = vstack((dc2, fake_cluster_sats))


### PR DESCRIPTION
This commit addresses GitHub Issue #69, which identified a small population of cluster satellites with identical gri restframe magnitudes. The cause of this problem is the way we boosted the mass-richness relation by resampling existing galaxies in the mock; the way this resampling was implemented led to occasional repeated selection of the same objects. 

It was further shown that the spatial positions of the galaxies with repeated magnitudes were unexpectedly concentrated. The source of this unphysically large concentration was the same source as the repeated magnitudes. Occasionally, the selected objects were originally located in a smaller-mass halo. So when we distributed the new objects according to an NFW profile, the spatial extent of the profile was being set by the mass of the original halo. 

This PR resolves this issue by remodeling this population with the same machinery used to model the original cluster satellites, entirely doing away with the resampling method that caused the problems.

CC @evevkovacs