### PR TITLE
Highmass cluster bugfix

### DIFF
--- a/cosmodc2/sdss_colors/sigmoid_magr_model.py
+++ b/cosmodc2/sdss_colors/sigmoid_magr_model.py
@@ -22,6 +22,10 @@ def sigmoid(x, x0=0, k=1, ymin=0, ymax=1):
 def magr_monte_carlo(mstar, upid, redshift, scatter=0.15, **kwargs):
     """
     """
+    mstar = np.atleast_1d(mstar)
+    upid = np.atleast_1d(upid)
+    redshift = np.atleast_1d(redshift)
+
     median_magr = median_magr_from_mstar(mstar, upid, redshift, **kwargs)
     with NumpyRNGContext(fixed_seed):
         result = np.random.normal(loc=median_magr, scale=scatter)

--- a/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
+++ b/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
@@ -118,8 +118,6 @@ def model_synthetic_cluster_satellites(mock, Lbox=256.,
 
         sats['halo_id'] = -1
         sats['source_halo_id'] = -1
-        sats['um_target_halo_id'] = -1
-        sats['um_target_halo_mass'] = sats['target_halo_mass']
         sats['source_halo_mvir'] = sats['target_halo_mass']
 
         #  Assign M* according to the Halotools implementation


### PR DESCRIPTION
This PR addresses the SM-HM relation in ultra-high mass Outer Rim halos, and also deletes the `um_target_halo_id` and `um_target_halo_mass` columns from the synthetic cluster satellites routines, as per instructions from @evevkovacs. 