### PR TITLE
V1 bugfix

### DIFF
--- a/cosmodc2/stellar_mass_remapping/remap_high_mass_smhm.py
+++ b/cosmodc2/stellar_mass_remapping/remap_high_mass_smhm.py
@@ -17,6 +17,7 @@ def remap_stellar_mass_in_snapshot(snapshot_redshift, mpeak, mstar,
     msg = "Input snapshot_redshift must be a single float.\nReceived an array of shape {0}"
     _x = np.atleast_1d(snapshot_redshift)
     assert len(_x) == 1, msg.format(_x.shape)
+    snapshot_redshift = _x[0]
 
     logmpeak_pivot = np.interp(snapshot_redshift, z_table, pivot_table)
     slope = np.interp(snapshot_redshift, z_table, slope_table)

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -537,7 +537,7 @@ def build_output_snapshot_mock(
                 "that does not contain the ``{0}`` key")
             raise KeyError(msg.format(key))
 
-    max_umachine_halo_mass = np.max(umachine['source_halo_mvir'])
+    max_umachine_halo_mass = np.max(umachine['mpeak'])
     ultra_high_mvir_halo_mask = (dc2['upid'] == -1) & (dc2['target_halo_mass'] > max_umachine_halo_mass)
     num_to_remap = np.count_nonzero(ultra_high_mvir_halo_mask)
     if num_to_remap > 0:

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -537,7 +537,8 @@ def build_output_snapshot_mock(
                 "that does not contain the ``{0}`` key")
             raise KeyError(msg.format(key))
 
-    ultra_high_mvir_halo_mask = (dc2['upid'] == -1) & (dc2['target_halo_mass'] > dc2['source_halo_mvir'].max())
+    max_umachine_halo_mass = np.max(umachine['source_halo_mvir'])
+    ultra_high_mvir_halo_mask = (dc2['upid'] == -1) & (dc2['target_halo_mass'] > max_umachine_halo_mass)
     num_to_remap = np.count_nonzero(ultra_high_mvir_halo_mask)
     if num_to_remap > 0:
         print("...remapping stellar mass of {0} BCGs in ultra-massive halos".format(num_to_remap))

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -539,7 +539,7 @@ def build_output_snapshot_mock(
     if num_to_remap > 0:
         dc2['obs_sm'][ultra_high_mvir_halo_mask] = remap_stellar_mass_in_snapshot(
             dc2['target_halo_redshift'][ultra_high_mvir_halo_mask],
-            dc2['mpeak'][ultra_high_mvir_halo_mask], dc2['obs_sm'][ultra_high_mvir_halo_mask])
+            dc2['target_halo_mass'][ultra_high_mvir_halo_mask], dc2['obs_sm'][ultra_high_mvir_halo_mask])
         dc2['restframe_extincted_sdss_abs_magr'][ultra_high_mvir_halo_mask] = magr_monte_carlo(
             dc2['obs_sm'][ultra_high_mvir_halo_mask], dc2['upid'][ultra_high_mvir_halo_mask],
             dc2['target_halo_redshift'][ultra_high_mvir_halo_mask])

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -540,12 +540,22 @@ def build_output_snapshot_mock(
     ultra_high_mvir_halo_mask = (dc2['upid'] == -1) & (dc2['target_halo_mass'] > dc2['source_halo_mvir'].max())
     num_to_remap = np.count_nonzero(ultra_high_mvir_halo_mask)
     if num_to_remap > 0:
+        print("...remapping stellar mass of {0} BCGs in ultra-massive halos".format(num_to_remap))
+
+        halo_mass_array = dc2['target_halo_mass'][ultra_high_mvir_halo_mask]
+        mstar_array = dc2['obs_sm'][ultra_high_mvir_halo_mask]
+        redshift_array = dc2['target_halo_redshift'][ultra_high_mvir_halo_mask]
+        upid_array = dc2['upid'][ultra_high_mvir_halo_mask]
+
+        assert np.shape(halo_mass_array) == (num_to_remap, ), "halo_mass_array has shape = {0}".format(np.shape(halo_mass_array))
+        assert np.shape(mstar_array) == (num_to_remap, ), "mstar_array has shape = {0}".format(np.shape(mstar_array))
+        assert np.shape(redshift_array) == (num_to_remap, ), "redshift_array has shape = {0}".format(np.shape(redshift_array))
+        assert np.shape(upid_array) == (num_to_remap, ), "upid_array has shape = {0}".format(np.shape(upid_array))
+
         dc2['obs_sm'][ultra_high_mvir_halo_mask] = remap_stellar_mass_in_snapshot(
-            snapshot_redshift, dc2['target_halo_mass'][ultra_high_mvir_halo_mask],
-            dc2['obs_sm'][ultra_high_mvir_halo_mask])
+            snapshot_redshift, halo_mass_array, mstar_array)
         dc2['restframe_extincted_sdss_abs_magr'][ultra_high_mvir_halo_mask] = magr_monte_carlo(
-            dc2['obs_sm'][ultra_high_mvir_halo_mask], dc2['upid'][ultra_high_mvir_halo_mask],
-            dc2['target_halo_redshift'][ultra_high_mvir_halo_mask])
+            mstar_array, upid_array, redshift_array)
 
     dc2['x'] = dc2['target_halo_x'] + dc2['host_centric_x']
     dc2['vx'] = dc2['target_halo_vx'] + dc2['host_centric_vx']

--- a/cosmodc2/write_umachine_healpix_mock_to_disk.py
+++ b/cosmodc2/write_umachine_healpix_mock_to_disk.py
@@ -355,7 +355,7 @@ def write_umachine_healpix_mock_to_disk(
         ########################################################################
 
         print("...building output snapshot mock for snapshot {}".format(snapshot))
-        output_mock[snapshot] = build_output_snapshot_mock(
+        output_mock[snapshot] = build_output_snapshot_mock(redshift,
                 mock, target_halos, source_galaxy_indx, galaxy_id_offset,
                 synthetic_dict, Nside_cosmoDC2, cutout_number, cutout_number_true,
                 halo_unique_id=halo_unique_id, redshift_method='halo', use_centrals=use_centrals)
@@ -444,7 +444,7 @@ def get_astropy_table(table_data, halo_unique_id=0, check=False):
 
 
 def build_output_snapshot_mock(
-            umachine, target_halos, galaxy_indices, galaxy_id_offset,
+            snapshot_redshift, umachine, target_halos, galaxy_indices, galaxy_id_offset,
             synthetic_dict, Nside, cutout_number, cutout_number_true,
             halo_unique_id=0, redshift_method='galaxy', use_centrals=True):
     """
@@ -452,6 +452,9 @@ def build_output_snapshot_mock(
 
     Parameters
     ----------
+    snapshot_redshift : float
+        Float of the snapshot redshift
+
     umachine : astropy.table.Table
         Astropy Table of shape (num_source_gals, )
         storing the UniverseMachine snapshot mock
@@ -538,8 +541,8 @@ def build_output_snapshot_mock(
     num_to_remap = np.count_nonzero(ultra_high_mvir_halo_mask)
     if num_to_remap > 0:
         dc2['obs_sm'][ultra_high_mvir_halo_mask] = remap_stellar_mass_in_snapshot(
-            dc2['target_halo_redshift'][ultra_high_mvir_halo_mask],
-            dc2['target_halo_mass'][ultra_high_mvir_halo_mask], dc2['obs_sm'][ultra_high_mvir_halo_mask])
+            snapshot_redshift, dc2['target_halo_mass'][ultra_high_mvir_halo_mask],
+            dc2['obs_sm'][ultra_high_mvir_halo_mask])
         dc2['restframe_extincted_sdss_abs_magr'][ultra_high_mvir_halo_mask] = magr_monte_carlo(
             dc2['obs_sm'][ultra_high_mvir_halo_mask], dc2['upid'][ultra_high_mvir_halo_mask],
             dc2['target_halo_redshift'][ultra_high_mvir_halo_mask])


### PR DESCRIPTION
This PR resolves a bug leading to the failed job reported by @evevkovacs. 

```
Traceback (most recent call last):
  File "run_cosmoDC2_healpix_production.py", line 156, in <module>
    nzdivs=args.nzdivs, Nside_cosmoDC2=args.nside, z2ts=z2ts)
  File 
"/home/ekovacs/cosmology/cosmodc2/cosmodc2/write_umachine_healpix_mock_to_disk.py", 
line 361, in write_umachine_healpix_mock_to_disk
    halo_unique_id=halo_unique_id, redshift_method='halo', 
use_centrals=use_centrals)
  File 
"/home/ekovacs/cosmology/cosmodc2/cosmodc2/write_umachine_healpix_mock_to_disk.py", 
line 542, in build_output_snapshot_mock
    dc2['mpeak'][ultra_high_mvir_halo_mask], 
dc2['obs_sm'][ultra_high_mvir_halo_mask])
  File 
"/home/ekovacs/cosmology/cosmodc2/cosmodc2/stellar_mass_remapping/remap_high_mass_smhm.py", 
line 26, in remap_stellar_mass_in_snapshot
    np.log10(mpeak), [logmpeak_low, logmpeak_high], [0, 1])
  File 
"/soft/libraries/anaconda-unstable/lib/python2.7/site-packages/numpy/lib/function_base.py", 
line 1663, in interp
    return compiled_interp(x, xp, fp, left, right)
ValueError: object too deep for desired array

```
I'm a little puzzled by this error and I'm not sure that this is the right fix. This "object too deep" error usually happens when the input array has the wrong shape, for example if np.interp is passed a 2-d array. At the very least, the `remap_stellar_mass_in_snapshot` function _should_ have been passed a float for the redshift, so that smells like the culprit even though the traceback does not quite make sense; this PR does fix that error by passing in the snapshot redshift rather than an array. 

Additionally, before calling the `remap_stellar_mass_in_snapshot` function from within the write_healpix script, I added in some assert statements to enforce that all arguments have the correct shape. So I think this code is ready to run again, and if it fails again then this time it will be more informative. 

@evevkovacs - if it is easy to run an interactive job using a single input file that failed, that would be ideal. If the code passes that trial, then we should resubmit the full job to hop back in the queue. 

CC @dkorytov @patricialarsen 