### PR TITLE
Code for producing snapshot catalog

### DIFF
--- a/cosmodc2/load_gio_halos.py
+++ b/cosmodc2/load_gio_halos.py
@@ -19,11 +19,11 @@ def load_gio_halo_snapshot(filename, all_properties=True):
     else:
         properties_list = []
     halo_properties_list = sorted([property_template.format(p) for p in other_properties + properties_list])
-    print('Reading halo file {}'.format(os.path.split(filename)[-1]))
+    print('.....Reading halo file {}'.format(os.path.split(filename)[-1]))
 
     halo_table = Table()
     for halo_prop in halo_properties_list:
-        print('Reading column {}'.format(halo_prop))
+        print('.....Reading column {}'.format(halo_prop))
         #cast properties into 1-d ndarray by selecting first element
         halo_table[halo_prop] = gio.gio_read(filename, halo_prop)[:,0]
 

--- a/cosmodc2/load_gio_halos.py
+++ b/cosmodc2/load_gio_halos.py
@@ -8,10 +8,14 @@ property_list = ['center_{}', 'mean_v{}']
 property_modifiers =['x', 'y', 'z']
 other_properties = ['tag', 'mass']
 
-def load_gio_halo_snapshot(filename, all_properties=True):
+def load_gio_halo_snapshot(filename, all_properties=True, block=None):
     import sys
-    sys.path.append("/gpfs/mira-home/ekovacs/cosmology/genericio/python")
-    import genericio as gio
+    if block is None:
+        sys.path.insert(0, "/gpfs/mira-home/ekovacs/cosmology/genericio/python")
+        import genericio as gio
+    else:
+        sys.path.insert(0, "/gpfs/mira-home/ekovacs/cosmology/gio_by_block")
+        import dtk as gio
 
     #gio.gio_inspect(filename) #list all properties
     if all_properties:
@@ -19,13 +23,17 @@ def load_gio_halo_snapshot(filename, all_properties=True):
     else:
         properties_list = []
     halo_properties_list = sorted([property_template.format(p) for p in other_properties + properties_list])
-    print('.....Reading halo file {}'.format(os.path.split(filename)[-1]))
+    blocktxt = '(block = {})'.format(str(block)) if block is not None else ''
+    print('.....Reading halo file {} {}'.format(os.path.split(filename)[-1], blocktxt))
 
     halo_table = Table()
     for halo_prop in halo_properties_list:
         print('.....Reading column {}'.format(halo_prop))
-        #cast properties into 1-d ndarray by selecting first element
-        halo_table[halo_prop] = gio.gio_read(filename, halo_prop)[:,0]
+        if block is not None:
+            halo_table[halo_prop] = gio.gio_read(filename, halo_prop, int(block))
+        else:
+            #cast properties into 1-d ndarray by selecting first element
+            halo_table[halo_prop] = gio.gio_read(filename, halo_prop)[:,0]
 
     return halo_table
 

--- a/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
+++ b/cosmodc2/synthetic_subhalos/synthetic_cluster_satellites.py
@@ -37,7 +37,7 @@ def calculate_synthetic_richness(halo_richness, logmhalo, logmhalo_source,
 
 def model_synthetic_cluster_satellites(mock, Lbox=256.,
         cluster_satboost_logm_table=[13.5, 13.75, 14],
-        cluster_satboost_table=[0., 0.15, 0.2], **kwargs):
+        cluster_satboost_table=[0., 0.15, 0.2], snapshot=False, **kwargs):
     """
     """
     #  Calculate the mass and richness of every target halo
@@ -54,8 +54,9 @@ def model_synthetic_cluster_satellites(mock, Lbox=256.,
     source_halo_mvir = mock['source_halo_mvir'][idx]
     target_halo_id = mock['target_halo_id'][idx]
     target_halo_fof_halo_id = mock['target_halo_fof_halo_id'][idx]
-    target_halo_lightcone_replication = mock['lightcone_replication'][idx]
-    target_halo_lightcone_rotation = mock['lightcone_rotation'][idx]
+    if not snapshot:
+        target_halo_lightcone_replication = mock['lightcone_replication'][idx]
+        target_halo_lightcone_rotation = mock['lightcone_rotation'][idx]
 
     host_richness = counts
 
@@ -81,8 +82,9 @@ def model_synthetic_cluster_satellites(mock, Lbox=256.,
         sats['target_halo_vz'] = np.repeat(host_vz, synthetic_richness)
         sats['target_halo_id'] = np.repeat(target_halo_id, synthetic_richness)
         sats['target_halo_fof_halo_id'] = np.repeat(target_halo_fof_halo_id, synthetic_richness)
-        sats['lightcone_replication'] = np.repeat(target_halo_lightcone_replication, synthetic_richness)
-        sats['lightcone_rotation'] = np.repeat(target_halo_lightcone_rotation, synthetic_richness)
+        if not snapshot:
+            sats['lightcone_replication'] = np.repeat(target_halo_lightcone_replication, synthetic_richness)
+            sats['lightcone_rotation'] = np.repeat(target_halo_lightcone_rotation, synthetic_richness)
 
         sats['upid'] = sats['target_halo_id']
 

--- a/cosmodc2/write_umachine_snapshot_mock_to_disk.py
+++ b/cosmodc2/write_umachine_snapshot_mock_to_disk.py
@@ -1,0 +1,456 @@
+""" Module storing the primary driver script used for the v1 release of cosmoDC2.
+"""
+import os
+import psutil
+import numpy as np
+import h5py
+import re
+import healpy as hp
+from time import time
+from astropy.table import Table, vstack
+from astropy.cosmology import FlatLambdaCDM
+from astropy.utils.misc import NumpyRNGContext
+from cosmodc2.load_gio_halos import load_gio_halo_snapshot
+from cosmodc2.sdss_colors import assign_restframe_sdss_gri
+from cosmodc2.sdss_colors.sigmoid_magr_model import magr_monte_carlo
+
+from cosmodc2.stellar_mass_remapping import remap_stellar_mass_in_snapshot
+from galsampler import halo_bin_indices, source_halo_index_selection
+from galsampler.cython_kernels import galaxy_selection_kernel
+from halotools.utils import crossmatch
+
+from cosmodc2.synthetic_subhalos import map_mstar_onto_lowmass_extension
+from cosmodc2.synthetic_subhalos import model_synthetic_cluster_satellites
+#from cosmodc2.synthetic_subhalos import synthetic_logmpeak
+
+fof_halo_mass = 'fof_halo_mass'
+mass = 'mass'
+fof_max = 14.5
+H0 = 71.0
+OmegaM = 0.2648
+OmegaB = 0.0448
+
+#unique galaxy_id
+galaxy_id_factor = int(1e3)  #  factor to guarantee unique galaxy_id across blocks in snapshot
+
+desired_logm_completeness=9.8
+
+def write_umachine_snapshot_mock_to_disk(
+        umachine_mock_fname, umachine_halo_fname,
+        target_halo_catalog_fname_list, snapshot, blocks, output_snapshot_mock_fname_list,
+        redshift, commit_hash, Lbox=3000.):
+    """
+    Main driver function used to paint SDSS fluxes onto UniverseMachine,
+    GalSample the mock into the halo snapshot and write the snapshot mock to disk.
+
+    Parameters
+    ----------
+    umachine_mock_fname : str 
+        the absolute path to the value-added UniverseMachine snapshot mock
+
+    umachine_halo_fname : str
+        the absolute path to the
+        value-added host halo catalog hosting the UniverseMachine snapshot mock
+
+    target_halo_catalog_fname : list
+        list of the absolute paths to the files of
+        source halos into which UniverseMachine will be GalSampled
+
+    snapshot : str
+        snapshot being processed
+
+    blocks : list  
+        list of blocks (str format) in of halo-catalog file being processed
+
+    output_snapshot_mock_fname_list : list
+        list of absolute paths to the output snapshot mock filenames
+
+    redshift : str
+        value of the redshift for the target halo catalog
+
+    commit_hash : string
+        Commit hash of the version of the cosmodc2 repo used when
+        calling this function.
+
+        After updating the cosmodc2 repo to the desired version,
+        the commit_hash can be determined by navigating to the root
+        directory and typing ``git log --pretty=format:'%h' -n 1``
+
+    """
+
+    start_time = time()
+    process = psutil.Process(os.getpid())
+    
+    #  determine factor for number of synthetic galaxies for this snapshot
+    #  synthetic_number_factor = (OR_size/MDPL2_size)**3
+
+    #  initialize book-keeping variables
+    fof_halo_mass_max = 0.
+    Ngals_total = 0
+
+    print('\nStarting snapshot processing')
+    print('Redshift for halo catalog = {}'.format(redshift))
+
+    #  Get galaxy properties from UM catalogs 
+    print("\n...loading z = {0:.2f} galaxy catalog into memory".format(redshift))
+    um_mock = Table.read(umachine_mock_fname, path='data')
+    print('.....{} galaxies read in'.format(len(um_mock)))
+
+    ### Get source halos 
+    print("\n...loading z = {0:.2f} source-halo catalogs into memory".format(redshift))
+    source_halos = Table.read(umachine_halo_fname, path='data')
+
+    #  Bin the halos in source simulation by mass
+    dlogM = 0.15
+    mass_bins = 10.**np.arange(10.5, 14.5+dlogM, dlogM)
+    source_halos['mass_bin'] = halo_bin_indices(
+        mass=(source_halos['mvir'], mass_bins))
+
+    for block, target_halo_fname, output_snap_fname  in zip(blocks,
+                                                           target_halo_catalog_fname_list,
+                                                           output_snapshot_mock_fname_list):
+        new_time_stamp = time()
+        #  determine seed from output filename (includes snapshot and block)
+        seed = get_random_seed(os.path.basename(output_snap_fname))
+        print('\n.Processing block {}'.format(block))
+        print('.Using galaxy_id factor {} + galaxy_id offset {}'.format(galaxy_id_factor, block))
+        print('.Using seed = {} (for block {})'.format(seed, block))
+
+        # copy um_mock to new table for this block
+        mock = um_mock.copy()
+        
+        print("\n...loading step {} fof target-halo catalogs into memory".format(snapshot))
+        target_halos = load_gio_halo_snapshot(target_halo_fname)
+        target_halos.rename_column('fof_halo_tag', 'fof_halo_id')
+        target_halos.rename_column('fof_halo_center_x', 'x')
+        target_halos.rename_column('fof_halo_center_y', 'y')
+        target_halos.rename_column('fof_halo_center_z', 'z')
+        target_halos.rename_column('fof_halo_mean_vx', 'vx')
+        target_halos.rename_column('fof_halo_mean_vy', 'vy')
+        target_halos.rename_column('fof_halo_mean_vz', 'vz')
+        max_fof_halo_mass = np.max(target_halos[fof_halo_mass].quantity.value)
+        fof_halo_mass_max = max(max_fof_halo_mass, fof_halo_mass_max)
+        print('.....Maximum fof halo mass = {:.3e}'.format(max_fof_halo_mass))
+
+        print("\n...Finding halo--halo correspondence with GalSampler")
+        #  Bin the halos in target simulation by mass
+        target_halos['mass_bin'] = halo_bin_indices(
+            mass=(target_halos[fof_halo_mass], mass_bins))
+
+        #  Randomly draw halos from corresponding mass bins
+        nhalo_min = 10
+        source_halo_bin_numbers = source_halos['mass_bin']
+        target_halo_bin_numbers = target_halos['mass_bin']
+        target_halo_ids = target_halos['fof_halo_id']
+        _result = source_halo_index_selection(source_halo_bin_numbers,
+                      target_halo_bin_numbers, target_halo_ids, nhalo_min, mass_bins, seed=seed)
+        source_halo_indx, matching_target_halo_ids = _result
+
+        #  Transfer quantities from the source halos to the corresponding target halo
+        target_halos['source_halo_id'] = source_halos['halo_id'][source_halo_indx]
+        target_halos['matching_mvir'] = source_halos['mvir'][source_halo_indx]
+        target_halos['richness'] = source_halos['richness'][source_halo_indx]
+        target_halos['first_galaxy_index'] = source_halos['first_galaxy_index'][source_halo_indx]
+
+        ################################################################################
+        #  Use GalSampler to calculate the indices of the galaxies that will be selected
+        ################################################################################
+        print("\n...GalSampling z={0:.2f} galaxies to OuterRim halos".format(redshift))
+
+        source_galaxy_indx = np.array(galaxy_selection_kernel(
+            target_halos['first_galaxy_index'].astype('i8'),
+            target_halos['richness'].astype('i4'), target_halos['richness'].sum()))
+
+        ########################################################################
+        #  Correct stellar mass for low-mass subhalos and create synthetic mpeak
+        ########################################################################
+        #print("...correcting low mass mpeak and assigning synthetic mpeak values")
+        #  First generate the appropriate number of synthetic galaxies for the snapshot
+        #mpeak_synthetic_snapshot = 10**synthetic_logmpeak(
+        #    mock['mpeak'], seed=seed, desired_logm_completeness=synthetic_halo_minimum_mass)
+        #print('...assembling {} synthetic galaxies'.format(len(mpeak_synthetic_snapshot)))
+
+        ########################################################################
+        #  Assign stellar mass
+        ########################################################################
+        print("...re-assigning high-mass mstar values")
+
+        #  Map stellar mass onto mock using target halo mass instead of UM Mpeak for cluster BCGs
+        new_mstar = remap_stellar_mass_in_snapshot(redshift, mock['mpeak'], mock['obs_sm'])
+        mock.rename_column('obs_sm', '_obs_sm_orig_um_snap')
+        mock['obs_sm'] = new_mstar
+
+        #  Add call to map_mstar_onto_lowmass_extension function after pre-determining low-mass slope
+        print("...re-assigning low-mass mstar values")
+        min_obs_sm = np.min(mock['obs_sm'])
+        mpeak_synthetic_snapshot = np.asarray([])
+        new_mstar_real, mstar_synthetic_snapshot = map_mstar_onto_lowmass_extension(
+            mock['mpeak'], mock['obs_sm'], mpeak_synthetic_snapshot,
+            desired_logm_completeness=desired_logm_completeness)
+        mock['obs_sm'] = new_mstar_real
+        new_min_obs_sm = np.min(mock['obs_sm'])
+        print('.....New min(obs_sm) = {:.3e}; old min(obs_sm) = {:.3e}'.format(new_min_obs_sm, min_obs_sm))
+        print('.....Number of shifted values = {}'.format(np.count_nonzero(mock['obs_sm'] < min_obs_sm)))
+
+        ###################################################
+        #  Map restframe Mr, g-r, r-i onto mock
+        ###################################################
+        #  use the redshift of the snapshot of the target simulation
+        print("...assigning rest-frame Mr and colors")
+        check_time = time()
+        redshift_mock = np.zeros(len(mock)) + redshift
+        msg = (".....using snapshot redshift to assign restframe colors")
+        print(msg)
+
+        magr, gr_mock, ri_mock, is_red_gr, is_red_ri = assign_restframe_sdss_gri(
+            mock['upid'], mock['obs_sm'], mock['sfr_percentile'],
+            mock['host_halo_mvir'], redshift_mock, seed=seed, use_substeps=False)
+        #  check for bad values
+        for m_id, m in zip(['magr', 'gr', 'ri'], [magr, gr_mock, ri_mock]):
+            num_infinite = np.sum(~np.isfinite(m))
+            if num_infinite > 0:
+                print('.....Warning: {} infinite values in mock {}'.format(num_infinite, m_id))
+
+        mock['restframe_extincted_sdss_abs_magr'] = magr
+        mock['restframe_extincted_sdss_gr'] = gr_mock
+        mock['restframe_extincted_sdss_ri'] = ri_mock
+        mock['is_on_red_sequence_gr'] = is_red_gr
+        mock['is_on_red_sequence_ri'] = is_red_ri
+        print('.....time to assign_restframe_sdss_gri = {:.2f} secs'.format(time()-check_time))
+
+        ########################################################################
+        #  Assemble the output mock by snapshot
+        ########################################################################
+
+        print("\n...building output snapshot mock for snapshot {}".format(snapshot))
+        output_mock = build_output_snapshot_mock(redshift, mock, target_halos,
+                                                          source_galaxy_indx, galaxy_id_factor,
+                                                          int(block), Lbox=Lbox)
+        Ngals_total += len(output_mock['galaxy_id'])
+        print('...saved {} galaxies to dict'.format(len(output_mock['galaxy_id'])))
+
+        ########################################################################
+        #  Write the output mock to disk
+        ########################################################################
+        if len(output_mock) > 0:
+            check_time = time()
+            write_output_mock_to_disk(output_snap_fname, output_mock, commit_hash, seed,
+                                      redshift, snapshot, block)
+            print('...time to write mock to disk = {:.2f} minutes'.format((time()-check_time)/60.))
+
+        time_stamp = time()
+        msg = "\n.Block runtime = {0:.2f} minutes"
+        print(msg.format((time_stamp-new_time_stamp)/60.))
+        mem = ".Memory usage =  {0:.2f} GB"
+        print(mem.format(process.memory_info().rss/1.e9))
+
+                                      
+    file_info = 'snapshot {}, blocks {}'.format(snapshot, ', '.join(blocks))
+    print('\n.Maximum halo mass in {} = {}\n'.format(file_info, fof_halo_mass_max))
+    print('.Number of galaxies in {} = {}\n'.format(file_info, Ngals_total))
+
+    time_stamp = time()
+    msg = "\nEnd-to-end runtime = {0:.2f} minutes\n"
+    print(msg.format((time_stamp-start_time)/60.))
+
+
+def get_random_seed(filename, seed_max=4294967095):  #reduce max seed by 200 to allow for 60 z shells
+    import hashlib
+    s = hashlib.md5(filename).hexdigest()
+    seed = int(s, 16)
+
+    #  enforce seed is below seed_max and odd
+    seed = seed%seed_max
+    if seed%2 == 0:
+        seed = seed + 1
+    return seed
+
+
+def build_output_snapshot_mock(
+            snapshot_redshift, umachine, target_halos, galaxy_indices, galaxy_id_factor,
+            galaxy_id_offset, Lbox=0.):
+    """
+    Collect the GalSampled snapshot mock into an astropy table
+
+    Parameters
+    ----------
+    snapshot_redshift : float
+        Float of the snapshot redshift
+
+    umachine : astropy.table.Table
+        Astropy Table of shape (num_source_gals, )
+        storing the UniverseMachine snapshot mock
+
+    target_halos : astropy.table.Table
+        Astropy Table of shape (num_target_halos, )
+        storing the target halo catalog
+
+    galaxy_indices: ndarray
+        Numpy indexing array of shape (num_target_gals, )
+        storing integers valued between [0, num_source_gals)
+
+    galaxy_id_factor: integer
+        Multiplicative factor to ensure unique galaxy id's in a snapshot
+
+    galaxy_id_offset: integer
+        Offset to ensure unique galaxy id's in a snapshot
+
+    Returns
+    -------
+    dc2 : astropy.table.Table
+        Astropy Table of shape (num_target_gals, )
+        storing the GalSampled galaxy catalog
+    """
+    dc2 = Table()
+    dc2['source_halo_id'] = umachine['hostid'][galaxy_indices]
+    dc2['target_halo_id'] = np.repeat(
+        target_halos['fof_halo_id'], target_halos['richness'])
+    #needed for synthetic cluster satellite assignment
+    dc2['target_halo_redshift'] = np.repeat(snapshot_redshift, len(dc2['target_halo_id']))
+    dc2['target_halo_fof_halo_id'] = dc2['target_halo_id']
+
+    #  copy target halo information
+    dc2['source_halo_mvir'] = np.repeat(
+        target_halos['matching_mvir'], target_halos['richness'])
+
+    idxA, idxB = crossmatch(dc2['target_halo_id'], target_halos['fof_halo_id'])
+
+    msg = "target IDs do not match!"
+    assert np.all(dc2['source_halo_id'][idxA] == target_halos['source_halo_id'][idxB]), msg
+
+    dc2['target_halo_x'] = 0.
+    dc2['target_halo_y'] = 0.
+    dc2['target_halo_z'] = 0.
+    dc2['target_halo_vx'] = 0.
+    dc2['target_halo_vy'] = 0.
+    dc2['target_halo_vz'] = 0.
+
+    dc2['target_halo_x'][idxA] = target_halos['x'][idxB]
+    dc2['target_halo_y'][idxA] = target_halos['y'][idxB]
+    dc2['target_halo_z'][idxA] = target_halos['z'][idxB]
+
+    dc2['target_halo_vx'][idxA] = target_halos['vx'][idxB]
+    dc2['target_halo_vy'][idxA] = target_halos['vy'][idxB]
+    dc2['target_halo_vz'][idxA] = target_halos['vz'][idxB]
+
+    dc2['target_halo_mass'] = 0.
+    dc2['target_halo_mass'][idxA] = target_halos['fof_halo_mass'][idxB]
+
+    source_galaxy_keys = ('host_halo_mvir', 'upid', 'mpeak',
+            'host_centric_x', 'host_centric_y', 'host_centric_z',
+            'host_centric_vx', 'host_centric_vy', 'host_centric_vz',
+            'obs_sm', 'obs_sfr', 'sfr_percentile',
+            'restframe_extincted_sdss_abs_magr',
+            'restframe_extincted_sdss_gr', 'restframe_extincted_sdss_ri',
+            'is_on_red_sequence_gr', 'is_on_red_sequence_ri',
+            '_obs_sm_orig_um_snap', 'halo_id')
+    for key in source_galaxy_keys:
+        try:
+            dc2[key] = umachine[key][galaxy_indices]
+        except KeyError:
+            msg = ("The build_output_snapshot_mock function was passed a umachine mock\n"
+                "that does not contain the ``{0}`` key")
+            raise KeyError(msg.format(key))
+
+    max_umachine_halo_mass = np.max(umachine['mpeak'])
+    ultra_high_mvir_halo_mask = (dc2['upid'] == -1) & (dc2['target_halo_mass'] > max_umachine_halo_mass)
+    num_to_remap = np.count_nonzero(ultra_high_mvir_halo_mask)
+    if num_to_remap > 0:
+        print("...remapping stellar mass of {0} BCGs in ultra-massive halos".format(num_to_remap))
+
+        halo_mass_array = dc2['target_halo_mass'][ultra_high_mvir_halo_mask]
+        mpeak_array = dc2['mpeak'][ultra_high_mvir_halo_mask]
+        mhalo_ratio = halo_mass_array/mpeak_array
+        mstar_array = dc2['obs_sm'][ultra_high_mvir_halo_mask]
+        redshift_array = dc2['target_halo_redshift'][ultra_high_mvir_halo_mask]
+        upid_array = dc2['upid'][ultra_high_mvir_halo_mask]
+
+        assert np.shape(halo_mass_array) == (num_to_remap, ), "halo_mass_array has shape = {0}".format(np.shape(halo_mass_array))
+        assert np.shape(mstar_array) == (num_to_remap, ), "mstar_array has shape = {0}".format(np.shape(mstar_array))
+        assert np.shape(redshift_array) == (num_to_remap, ), "redshift_array has shape = {0}".format(np.shape(redshift_array))
+        assert np.shape(upid_array) == (num_to_remap, ), "upid_array has shape = {0}".format(np.shape(upid_array))
+        assert np.all(mhalo_ratio >= 1), "Bookkeeping error: all values of mhalo_ratio ={0} should be >= 1".format(mhalo_ratio)
+
+        dc2['obs_sm'][ultra_high_mvir_halo_mask] = mstar_array*(mhalo_ratio**0.5)
+        dc2['restframe_extincted_sdss_abs_magr'][ultra_high_mvir_halo_mask] = magr_monte_carlo(
+            dc2['obs_sm'][ultra_high_mvir_halo_mask], upid_array, redshift_array)
+        idx = np.argmax(dc2['obs_sm'])
+        halo_id_most_massive = dc2['halo_id'][idx]
+        assert dc2['obs_sm'][idx] < 10**13.5, "halo_id = {0} has stellar mass {1:.3e}".format(
+            halo_id_most_massive, dc2['obs_sm'][idx])
+
+    dc2['x'] = dc2['target_halo_x'] + dc2['host_centric_x']
+    dc2['vx'] = dc2['target_halo_vx'] + dc2['host_centric_vx']
+
+    dc2['y'] = dc2['target_halo_y'] + dc2['host_centric_y']
+    dc2['vy'] = dc2['target_halo_vy'] + dc2['host_centric_vy']
+
+    dc2['z'] = dc2['target_halo_z'] + dc2['host_centric_z']
+    dc2['vz'] = dc2['target_halo_vz'] + dc2['host_centric_vz']
+
+    print('...number of galaxies before adding synthetic satellites = {}'.format(len(dc2['halo_id'])))
+    print("...generating and stacking any synthetic cluster satellites")
+    fake_cluster_sats = model_synthetic_cluster_satellites(dc2, Lbox=Lbox, snapshot=True)
+    if len(fake_cluster_sats) > 0:
+        check_time = time()
+        dc2 = vstack((dc2, fake_cluster_sats))
+        print('...time to create {} galaxies in fake_cluster_sats = {:.2f} secs'.format(len(fake_cluster_sats['target_halo_id']), time()-check_time))
+
+    # delete duplicate/unnecessary column after fake cluster satellites are added
+    dc2.remove_column('target_halo_fof_halo_id')
+    dc2.remove_column('target_halo_redshift')
+
+    dc2['galaxy_id'] = np.arange(len(dc2['target_halo_id'])).astype(int)*galaxy_id_factor + galaxy_id_offset
+    print('...Min and max galaxy_id = {} -> {}'.format(np.min(dc2['galaxy_id']), np.max(dc2['galaxy_id'])))
+
+    #  Use gr and ri color to compute gi flux
+    dc2['restframe_extincted_sdss_abs_magg'] = (
+        dc2['restframe_extincted_sdss_gr'] +
+        dc2['restframe_extincted_sdss_abs_magr'])
+    dc2['restframe_extincted_sdss_abs_magi'] = (
+        -dc2['restframe_extincted_sdss_ri'] +
+        dc2['restframe_extincted_sdss_abs_magr'])
+
+    #convert table to dict
+    check_time = time()
+    output_dc2 = {}
+    for k in dc2.keys():
+        output_dc2[k] = dc2[k].quantity.value
+
+    print('...time to new dict = {:.4f} secs'.format(time()-check_time))
+
+    return output_dc2
+
+
+def write_output_mock_to_disk(output_snapshot_mock_fname, output_mock, commit_hash, seed,
+                              redshift, snapshot, block,
+                              versionMajor=0, versionMinor=1, versionMinorMinor=0):
+    """
+    """
+
+    print("\n...writing to file {} using commit hash {}".format(output_snapshot_mock_fname, commit_hash))
+    hdfFile = h5py.File(output_snapshot_mock_fname, 'w')
+    hdfFile.create_group('metaData')
+    hdfFile['metaData']['commit_hash'] = commit_hash
+    hdfFile['metaData']['seed'] = seed
+    hdfFile['metaData']['versionMajor'] = versionMajor
+    hdfFile['metaData']['versionMinor'] = versionMinor
+    hdfFile['metaData']['versionMinorMinor'] = versionMinorMinor
+    hdfFile['metaData']['H_0'] = H0
+    hdfFile['metaData']['Omega_matter'] = OmegaM
+    hdfFile['metaData']['Omega_b'] = OmegaB
+    hdfFile['metaData']['redshift'] = redshift
+    hdfFile['metaData']['timestep'] = snapshot
+    hdfFile['metaData']['block_number'] = block
+
+    zkey = 'z={:.4f}'.format(redshift)
+    gGroup = hdfFile.create_group(zkey)
+    check_time = time()
+    for k, v in output_mock.items():
+        gGroup[k] = v
+
+    print('.....time to write group {} = {:.4f} secs'.format(zkey, time()-check_time))
+
+    check_time = time()
+    hdfFile.close()
+    print('.....time to close file {:.4f} secs'.format(time()-check_time))

--- a/cosmodc2/write_umachine_snapshot_mock_to_disk.py
+++ b/cosmodc2/write_umachine_snapshot_mock_to_disk.py
@@ -235,7 +235,7 @@ def write_umachine_snapshot_mock_to_disk(
         if len(output_mock) > 0:
             check_time = time()
             write_output_mock_to_disk(output_snap_fname, output_mock, commit_hash, seed,
-                                      redshift, snapshot, block)
+                                      redshift, snapshot, block, Lbox)
             print('...time to write mock to disk = {:.2f} minutes'.format((time()-check_time)/60.))
 
         time_stamp = time()
@@ -423,7 +423,7 @@ def build_output_snapshot_mock(
 
 
 def write_output_mock_to_disk(output_snapshot_mock_fname, output_mock, commit_hash, seed,
-                              redshift, snapshot, block,
+                              redshift, snapshot, block, Lbox,
                               versionMajor=0, versionMinor=1, versionMinorMinor=0):
     """
     """
@@ -439,6 +439,7 @@ def write_output_mock_to_disk(output_snapshot_mock_fname, output_mock, commit_ha
     hdfFile['metaData']['H_0'] = H0
     hdfFile['metaData']['Omega_matter'] = OmegaM
     hdfFile['metaData']['Omega_b'] = OmegaB
+    hdfFile['metaData']['box_size'] = Lbox
     hdfFile['metaData']['redshift'] = redshift
     hdfFile['metaData']['timestep'] = snapshot
     hdfFile['metaData']['block_number'] = block

--- a/scripts/bundle_cosmodc2_snapshot_blocks.sh
+++ b/scripts/bundle_cosmodc2_snapshot_blocks.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+NODES=`cat $COBALT_NODEFILE | wc -l`
+PROCS=1
+nblock=0
+# starting block number 
+cd /gpfs/mira-home/ekovacs/cosmology/DC2/cosmoDC2/OR_Snapshots
+export PYTHONDIRS=/gpfs/mira-home/ekovacs/.local/lib/python2.7/site-packages:/gpfs/mira-home/ekovacs/cosmology/cosmodc2:/gpfs/mira-home/ekovacs/cosmology/galsampler/build/lib.linux-x86_64-2.7:/gpfs/mira-home/ekovacs/cosmology/halotools/build/lib.linux-x86_64-2.7
+PYTHONPATH=/gpfs/mira-home/ekovacs/.local/lib/python2.7/site-packages:/gpfs/mira-home/ekovacs/cosmology/cosmodc2:/gpfs/mira-home/ekovacs/cosmology/galsampler/build/lib.linux-x86_64-2.7:/gpfs/mira-home/ekovacs/cosmology/halotools/build/lib.linux-x86_64-2.7
+export PYTHONPATH
+vsnap="snapshots_v0.1"
+xtra_args="-input_master_dirname cosmology/DC2/OR_Snapshots -output_mock_dirname baseDC2_${vsnap}"
+snapshot=${1}
+echo "Running snapshot ${1}"
+total_block_num=128
+blocks_per_node=16
+blocks_per_core=2
+jobs_per_node=8
+
+script_name=run_cosmoDC2_snapshot_production.py
+pythonpath=/soft/libraries/anaconda-unstable/bin/python
+
+readarray nodenumbers < $COBALT_NODEFILE
+subgrp=0
+for nodenumber in "${nodenumbers[@]}"
+#for nodenumber in {1..3}
+do
+  hostname1=$nodenumber
+  #hostname1=expr xargs $nodenumber
+  #hostname1=${ xargs $nodenumber}
+  hostname1=${hostname1%?}
+  #echo $hostname1
+  #hostname1=$(cat $COBALT_NODEFILE | awk 'NR=='${nodenumber})
+  for filenumber in {0..7}
+  do
+  if [ "$nblock" -lt "$total_block_num" ]
+  then
+  sublo=$(expr $subgrp + $filenumber \* $blocks_per_core )
+  subhi=$(expr $sublo + $blocks_per_core - 1 )
+  blockrange="$sublo-$subhi"
+  echo "$blockrange"
+  echo "${blockrange}" >> started_blocks.txt
+  args="${snapshot} -blocks ${blockrange} ${xtra_args}"
+  #echo $args
+  #   mpirun --host ${hostname1}
+  #echo ${hostname1}_${COBALT_JOBID}_${blockelname}-err.log
+  jobname="Step${snapshot}_${blockrange}_${vsnap}_${hostname1}_${COBALT_JOBID}.log"
+  mpirun --host ${hostname1} -n $PROCS $pythonpath $script_name ${args} > $jobname 2>&1 & 
+  #echo "mpirun --host ${hostname1} -n $PROCS $pythonpath $script_name ${args}" > $jobname 2>&1 &
+  nblock=$(expr $nblock + $blocks_per_core)
+  else
+  echo "$nblock > maximum number of blocks"
+  fi
+  done
+  subgrp=$(expr $subgrp + $blocks_per_node)
+done
+echo "$nblock" >> restart_nblock.txt
+wait

--- a/scripts/run_cosmoDC2_snapshot_mocks.csh
+++ b/scripts/run_cosmoDC2_snapshot_mocks.csh
@@ -1,0 +1,66 @@
+#!/bin/csh
+#
+if ($#argv < 1 ) then
+    echo 'Usage: run_cosmoDC2_mocks timesteps blocks [mode] [timelimit]'
+    echo 'Script runs or submits job for creating cosmoDC2 snapshot mock'
+    echo 'timesteps = timesteps to run'
+    echo 'blocks = blocks to process [0-255]'
+    echo 'mode = test or qsub (default) or qtest'
+    echo 'timelimit = timelimit for qsub mode (default = 5 minutes)'
+    echo 'qsub runs production script in batch mode'
+    echo 'test runs production script interactively'
+    echo 'qtest runs production script in batch mode with -h option'
+    echo 'output is written to the submit directory'
+    exit
+endif
+
+set jobname = "$Step{1}_#${2}"
+set timesteps = "${1}"
+set blocks = ${2}
+set mode = "qsub"
+set timelimit = "5"
+if ($#argv > 2 ) then
+    if(${3} == "qsub" || ${3} == "test" || ${3} == "qtest") then
+	set mode = "${3}"
+    else
+	set timelimit = "${3}"
+    endif
+    if ($#argv > 3 ) then
+	if(${4} == "qsub" || ${4} == "test" || ${4} == "qtest") then
+	    set mode = "${4}"
+	else
+	    set timelimit = "${4}"
+	endif
+    endif
+endif
+
+set script_name = "run_cosmoDC2_snapshot_production.py"
+set python = "/soft/libraries/anaconda-unstable/bin/python"
+set version = "0.1"
+set xtra_label = "snapshots_v${version}"
+set xtra_args = "-input_master_dirname cosmology/DC2/OR_Snapshots -output_mock_dirname baseDC2_${xtra_label}"
+if(${xtra_label} != "") then
+    set jobname = ${jobname}_${xtra_label}
+endif
+set args = "${timesteps} -blocks ${block} ${xtra_args}"
+
+set pythondirs = /gpfs/mira-home/ekovacs/.local/lib/python2.7/site-packages:/gpfs/mira-home/ekovacs/cosmology/cosmodc2:/gpfs/mira-home/ekovacs/cosmology/galsampler/build/lib.linux-x86_64-2.7:/gpfs/mira-home/ekovacs/cosmology/halotools/build/lib.linux-x86_64-2.7
+
+setenv PYTHONPATH ${pythondirs}
+echo "Using PYTHONPATH $PYTHONPATH"
+
+msg1 = "Running ${script_name}"
+msg2 = "to create snapshot for Step ${timestep} for block(s) ${block} in ${mode} mode"
+
+if(${mode} == "test") then
+    echo "${msg1} interactively ${msg2}"
+    ${python} ${script_name} ${args}
+else
+    if(${mode} == "qtest") then
+	echo "${msg1} -h in ${mode} mode"
+	qsub -n 1 -t 5 -A ExtCosmology_2 -O ${jobname}.\$jobid --env PYTHONPATH=${pythondirs} ${python} ./${script_name} -h
+    else
+	echo "${msg1} ${msg2} with time limit of ${timelimit} minutes"
+	qsub -n 1 -t ${timelimit} -A ExtCosmology_2 -O ${jobname}.\$jobid --env PYTHONPATH=${pythondirs} ${python} ./${script_name} ${args}
+    endif
+endif

--- a/scripts/run_cosmoDC2_snapshot_production.py
+++ b/scripts/run_cosmoDC2_snapshot_production.py
@@ -1,0 +1,151 @@
+import sys
+import os
+import glob
+import argparse
+import pickle
+import re
+import numpy as np
+from os.path import expanduser
+import subprocess
+
+#halo_snapshot_fname = '03_31_2018.OR.{}.fofproperties#{}'
+halo_fname_template = '{}.{}#{}'
+sim_name='AlphaQ'
+pklname='{}_z2ts.pkl'
+
+def retrieve_commit_hash(path_to_repo):
+    """ Return the commit hash of the git branch currently live in the input path.
+    Parameters
+    ----------
+    path_to_repo : string
+    Returns
+    -------
+    commit_hash : string
+    """
+    cmd = 'cd {0} && git rev-parse HEAD'.format(path_to_repo)
+    return subprocess.check_output(cmd, shell=True).strip()
+
+
+home = expanduser("~")
+path_to_cosmodc2 = os.path.join(home, 'cosmology/cosmodc2')
+if 'mira-home' in home:
+    sys.path.insert(0, '/gpfs/mira-home/ekovacs/.local/lib/python2.7/site-packages')
+sys.path.insert(0, path_to_cosmodc2)
+sys.path.insert(0, os.path.join(home, 'cosmology/galsampler/build/lib.linux-x86_64-2.7'))
+sys.path.insert(0, os.path.join(home, 'cosmology/halotools/build/lib.linux-x86_64-2.7'))
+
+from cosmodc2.write_umachine_snapshot_mock_to_disk import write_umachine_snapshot_mock_to_disk
+                                            
+parser = argparse.ArgumentParser()
+
+parser.add_argument("timesteps", nargs='+', metavar='timesteps', default=['247'],
+                    choices=['499', '475', '464', '453', '442', '432', '421', '411', '401', '392', '382', '373',
+                             '365', '355', '347', '338', '331', '323', '315', '307', '300', '293', '286', '279',
+                             '272', '266', '259', '253', '247', '241', '235', '230', '224', '219', '213', '208',
+                             '203', '198', '194', '189', '184', '180', '176', '171', '167', '163', '159', '155',
+                             '151', '148', '144', '141', '137', '134', '131', '127', '124'],
+                    help="Timesteps of snapshots to run; choose from: {%(choices)s}")
+#parser.add_argument("commit_hash",
+#    help="Commit hash to save in output files")
+parser.add_argument("-input_master_dirname",
+    help="Directory name (relative to home) storing sub-directories of input and output files",
+    default='cosmology/DC2/OR_Snapshots')
+parser.add_argument("-input_halo_catalog_dirname",
+    help="Directory name (relative to input_master_dirname) storing halo-catalog files",
+    default='OR_HaloCatalog')
+parser.add_argument("-input_halo_catalog_filename",
+    help="Filename for halo-catalog files",
+    default='test')
+parser.add_argument("-um_input_catalogs_dirname",
+    help="Directory name (relative to input_master_dirname) storing um input catalogs",
+    default='um_snapshots')
+parser.add_argument("-output_mock_dirname",
+    help="Directory name (relative to input_master_dirname) storing output snapshot files",
+    default='baseDC2_snapshots')
+parser.add_argument("-pkldirname",
+    help="Directory name (relative to home) storing pkl file with snapshot <-> redshift correspondence",
+    default='cosmology/cosmodc2/cosmodc2')
+parser.add_argument("-blocks",
+                    help="block(s) to run [0-255] (eg. 0 1 10-20 200-255 or combinations)", 
+                    nargs='+', default='0')                
+parser.add_argument("-verbose",
+    help="Turn on extra printing",
+        action='store_true', default=False)
+        
+args = parser.parse_args()
+
+#setup directory names
+input_master_dirname = os.path.join(home, args.input_master_dirname)
+pkldirname = os.path.join(home, args.pkldirname)
+input_halo_catalog_dirname = os.path.join(input_master_dirname, args.input_halo_catalog_dirname)
+output_mock_dirname = os.path.join(input_master_dirname, args.output_mock_dirname)
+timesteps = args.timesteps
+
+commit_hash = retrieve_commit_hash(path_to_cosmodc2)[0:7]
+print('Using commit hash {}'.format(commit_hash))
+
+if args.verbose:
+    print("paths=", home, path_to_cosmodc2, sys.path)
+
+#determine blocks to be processed
+blocks = []
+for block in args.blocks:
+    if '-' in block:
+        r_min, r_max = re.split('-', block)
+        rvals = [str(r) for r in range(int(r_min), int(r_max) + 1)]
+        blocks = blocks + rvals
+    else:
+        blocks.append(str(block))
+if args.verbose:
+    print('Processing blocks {}'.format(', '.join(blocks)))
+    
+
+#determine snapshot inputs required
+z2ts = pickle.load(open(os.path.join(pkldirname, pklname.format(sim_name)),'rb'))
+redshift_strings = [key for key in sorted(z2ts.keys()) if str(z2ts[key]) in timesteps]
+redshift_list = [float(z) for z in redshift_strings]
+expansion_factors = [1./(1+float(z)) for z in redshift_strings]
+if args.verbose:
+    print("target z's and a's:", redshift_strings, expansion_factors)
+
+#determine UM inputs available and match them to requested timesteps
+umachine_mstar_ssfr_mock_dirname = os.path.join(input_master_dirname, args.um_input_catalogs_dirname)
+sfr_files = sorted([os.path.basename(f) for f in glob.glob(umachine_mstar_ssfr_mock_dirname+'/sfr*')])
+um_expansion_factors = np.asarray([float(f.split('sfr_catalog_')[-1].split('_value_added.hdf5')[0]) for f in sfr_files])
+closest_snapshots = [np.abs(um_expansion_factors - a).argmin() for a in expansion_factors]
+if(args.verbose):
+    print('index of closest snapshots:',closest_snapshots)
+umachine_mstar_ssfr_mock_basename_list = [sfr_files[n] for n in closest_snapshots]
+umachine_mstar_ssfr_mock_fname_list = list((os.path.join(umachine_mstar_ssfr_mock_dirname, basename)
+                                            for basename in umachine_mstar_ssfr_mock_basename_list))
+if args.verbose:
+    print('umachine_mstar_ssfr_mock_basename_list:',umachine_mstar_ssfr_mock_basename_list)
+umachine_host_halo_dirname = os.path.join(input_master_dirname, args.um_input_catalogs_dirname)
+umachine_host_halo_basename_list = [sfr_files[n].replace('sfr', 'halo') for n in closest_snapshots]
+umachine_host_halo_fname_list = list((os.path.join(umachine_host_halo_dirname, basename) 
+                                      for basename in umachine_host_halo_basename_list))
+if args.verbose:
+    print('umachine_host_halo_fname_list:',umachine_host_halo_basename_list)
+
+#loop over requested timesteps
+for timestep, redshift, um_mstar_ssfr_fname, um_host_halo_fname in zip(timesteps, redshift_list, 
+                                                            umachine_mstar_ssfr_mock_fname_list, 
+                                                            umachine_host_halo_fname_list):
+    #get list of input files for requested blocks 
+    input_halo_catalog_fname_list = list((os.path.join(input_halo_catalog_dirname, 'STEP{}'.format(timestep),
+                                                       halo_fname_template.format(args.input_halo_catalog_filename,
+                                                                                  timestep, block))
+                                          for block in blocks))
+    print('Processing halo snapshot file(s) {}'.format(', '.join(input_halo_catalog_fname_list)))
+    output_snapshot_mock_fname_list = list((os.path.join(output_mock_dirname, 'STEP'+ timestep,
+                                                         '_'.join(["baseDC2",'Step'+timestep, 'z'+str(redshift),
+                                                                   '#'+block+'.hdf5']))
+                                            for block in blocks))
+    
+    if args.verbose:
+        print('output_snapshot_mock_fname_list: {}'.format(', '.join(output_snapshot_mock_fname_list)))
+
+    write_umachine_snapshot_mock_to_disk(
+        um_mstar_ssfr_fname, um_host_halo_fname,
+        input_halo_catalog_fname_list, timestep, blocks, output_snapshot_mock_fname_list,
+        redshift, commit_hash)

--- a/scripts/run_cosmoDC2_snapshot_production.py
+++ b/scripts/run_cosmoDC2_snapshot_production.py
@@ -9,7 +9,6 @@ from os.path import expanduser
 import subprocess
 
 #halo_snapshot_fname = '03_31_2018.OR.{}.fofproperties#{}'
-halo_fname_template = '{}.{}#{}'
 sim_name='AlphaQ'
 pklname='{}_z2ts.pkl'
 
@@ -55,7 +54,7 @@ parser.add_argument("-input_halo_catalog_dirname",
     default='OR_HaloCatalog')
 parser.add_argument("-input_halo_catalog_filename",
     help="Filename for halo-catalog files",
-    default='test')
+    default='03_31_2018.OR.{}.fofproperties')
 parser.add_argument("-um_input_catalogs_dirname",
     help="Directory name (relative to input_master_dirname) storing um input catalogs",
     default='um_snapshots')
@@ -132,11 +131,10 @@ for timestep, redshift, um_mstar_ssfr_fname, um_host_halo_fname in zip(timesteps
                                                             umachine_mstar_ssfr_mock_fname_list, 
                                                             umachine_host_halo_fname_list):
     #get list of input files for requested blocks 
-    input_halo_catalog_fname_list = list((os.path.join(input_halo_catalog_dirname, 'STEP{}'.format(timestep),
-                                                       halo_fname_template.format(args.input_halo_catalog_filename,
-                                                                                  timestep, block))
-                                          for block in blocks))
-    print('Processing halo snapshot file(s) {}'.format(', '.join(input_halo_catalog_fname_list)))
+    input_halo_catalog_fname = os.path.join(input_halo_catalog_dirname,
+                                            args.input_halo_catalog_filename.format(timestep))
+
+    print('Processing halo snapshot file {}, blocks {}'.format(input_halo_catalog_fname, ', '.join(blocks)))
     output_snapshot_mock_fname_list = list((os.path.join(output_mock_dirname, 'STEP'+ timestep,
                                                          '_'.join(["baseDC2",'Step'+timestep, 'z'+str(redshift),
                                                                    '#'+block+'.hdf5']))
@@ -147,5 +145,5 @@ for timestep, redshift, um_mstar_ssfr_fname, um_host_halo_fname in zip(timesteps
 
     write_umachine_snapshot_mock_to_disk(
         um_mstar_ssfr_fname, um_host_halo_fname,
-        input_halo_catalog_fname_list, timestep, blocks, output_snapshot_mock_fname_list,
+        input_halo_catalog_fname, timestep, blocks, output_snapshot_mock_fname_list,
         redshift, commit_hash)

--- a/scripts/submit_snapshot.sh
+++ b/scripts/submit_snapshot.sh
@@ -2,5 +2,5 @@
 export EMAIL=kovacs@anl.gov
 echo "Submitting jobs for snaphot ${1}"
 
-#qsub -n 1 -t 00:10:00 -A ExtCosmology_2 -M ${EMAIL} ./bundle_cosmodc2_z_0.sh
-qsub -n 8 -t 02:00:00 -A ExtCosmology_2 -M ${EMAIL} ./bundle_cosmodc2_snapshot_blocks.sh ${1}
+#qsub -n 15 -t 00:10:00 -A ExtCosmology_2 -M ${EMAIL} ./bundle_cosmodc2_snapshot_blocks.sh ${1}
+qsub -n 15 -t 02:00:00 -A ExtCosmology_2 -M ${EMAIL} ./bundle_cosmodc2_snapshot_blocks.sh ${1}

--- a/scripts/submit_snapshot.sh
+++ b/scripts/submit_snapshot.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+export EMAIL=kovacs@anl.gov
+echo "Submitting jobs for snaphot ${1}"
+
+#qsub -n 1 -t 00:10:00 -A ExtCosmology_2 -M ${EMAIL} ./bundle_cosmodc2_z_0.sh
+qsub -n 8 -t 02:00:00 -A ExtCosmology_2 -M ${EMAIL} ./bundle_cosmodc2_snapshot_blocks.sh ${1}


### PR DESCRIPTION
Code for producing baseDC2 snapshot catalog.
Code currently processes subfiles rather than blocks. Block processing (=sub-volume processing) is waiting on an improved python version of the gio reader. This should be a small change once the python capability is available.
Code has been tested and run to produce 2 snapshot catalogs for Step 432 (z=0.15) and Step 247 (z=1.0). It takes about 5-10 minutes to run in parallel over 8 nodes on cooley. Each node runs 8 groups of 2 subfiles. 