### PR TITLE
Changes to fix bug in synthetic halo positions

### DIFF
--- a/cosmodc2/get_healpix_cutout_info.py
+++ b/cosmodc2/get_healpix_cutout_info.py
@@ -20,3 +20,12 @@ def get_healpix_cutout_info(pkldirname, infile, sim_name='AlphaQ', pklname='{}_z
         print('{} not found'.format(infile))
 
     return h5file, redshifts, snapshots, z2ts
+
+def get_snap_redshift_min(z2ts, snapshots):
+    assert (len(z2ts) > 0), 'z2ts data NOT supplied'
+    all_snapshots =  sorted([v for v in z2ts.values()])[::-1]
+    # find redshift of preceding snapshot (499 is at index 0 and is never in snapshots list)
+    previous_snap = all_snapshots[all_snapshots.index(int(max(snapshots))) - 1]
+    previous_redshift = list(z2ts.keys())[z2ts.values().index(previous_snap)]
+    
+    return previous_redshift

--- a/scripts/run_cosmoDC2_5000_mocks_9.8_centrals_production.csh
+++ b/scripts/run_cosmoDC2_5000_mocks_9.8_centrals_production.csh
@@ -54,9 +54,9 @@ if(${mode} == "test") then
 else
     if(${mode} == "qtest") then
 	echo "Running ${script_name} -h in ${mode} mode"
-	qsub -n 1 -t 5 -A ExtCosmology_2 -O ${jobname}.\$jobid --env PYTHONPATH=${pythondirs} ${python} ./${script_name} -h
+	qsub -n 1 -t 5 -A LSSTsky -O ${jobname}.\$jobid --env PYTHONPATH=${pythondirs} ${python} ./${script_name} -h
     else
 	echo "Running ${script_name} to create ${filename} for z-range ${z_range} in ${mode} mode with time limit of ${timelimit} minutes"
-	qsub -n 1 -t ${timelimit} -A ExtCosmology_2 -O ${jobname}.\$jobid --env PYTHONPATH=${pythondirs} ${python} ./${script_name} ${args}
+	qsub -n 1 -t ${timelimit} -A LSSTsky -O ${jobname}.\$jobid --env PYTHONPATH=${pythondirs} ${python} ./${script_name} ${args}
     endif
 endif

--- a/scripts/run_cosmoDC2_healpix_production.py
+++ b/scripts/run_cosmoDC2_healpix_production.py
@@ -113,7 +113,8 @@ for zdir in z_range_dirs:
     #get list of snapshots 
     healpix_cutout_fname = os.path.join(healpix_cutout_dirname, zdir, args.healpix_fname)
     print('Processing healpix cutout {}'.format(healpix_cutout_fname))
-    healpix_data, redshift_strings, snapshots, z2ts  = get_healpix_cutout_info(pkldirname, healpix_cutout_fname, sim_name='AlphaQ')
+    healpix_data, redshift_strings, snapshots, z2ts = get_healpix_cutout_info(pkldirname,
+                                                                              healpix_cutout_fname, sim_name='AlphaQ')
 
     if args.ndebug_snaps > 0:
         
@@ -161,8 +162,7 @@ for zdir in z_range_dirs:
             healpix_data, snapshots, output_healpix_mock_fname, shape_dir,
             redshift_list, commit_hash, synthetic_halo_minimum_mass=synthetic_halo_minimum_mass,
             use_centrals=use_centrals, gaussian_smearing_real_redshifts=args.gaussian_smearing, 
-            nzdivs=args.nzdivs, Nside_cosmoDC2=args.nside, z2ts=z2ts, )
+            nzdivs=args.nzdivs, Nside_cosmoDC2=args.nside, z2ts=z2ts)
 
     else:
         print('Skipping empty healpix-cutout file {}'.format(args.healpix_fname))
-        


### PR DESCRIPTION
This PR addresses issue #97 and fixes the bug in generating the positions of synthetic galaxies for healpixels that contain very few halos. Positions are no longer based on halo positions but instead on the boundaries of the healpixel.