### PR TITLE
Adjustments for z=0 numerical issues

### DIFF
--- a/cosmodc2/synthetic_subhalos/extend_subhalo_mpeak_range.py
+++ b/cosmodc2/synthetic_subhalos/extend_subhalo_mpeak_range.py
@@ -207,7 +207,7 @@ def get_box_boundaries(Nside, cutout_id, rmin, rmax):
 box_zero = 1.e-6  #minimum value of position coordinate in box
 
 def get_volume_factor(box_mins, box_maxs, Nside, cutout_id, r_min, r_max, 
-                      volume_minx=box_zero, volume_miny=box_zero, volume_maxz=box_zero, Nsample=100000):
+                      volume_minx=box_zero, volume_miny=box_zero, volume_maxz=-box_zero, Nsample=100000):
     volume_factor = 1.0
     volume_box = (box_maxs[0] - box_mins[0])*(box_maxs[1] - box_mins[1])*(box_maxs[2] - box_mins[2])
     
@@ -283,7 +283,7 @@ def create_synthetic_lowmass_mock_with_centrals(
             mock, healpix_mock, synthetic_dict,
             snapshot_redshift_min, snapshot_redshift_max, cosmology,
             cutout_id=None, Nside=32, H0=71., Ntrial_min=3000,
-            volume_minx=box_zero, volume_miny=box_zero, volume_maxz=box_zero,
+            volume_minx=box_zero, volume_miny=box_zero, volume_maxz=-box_zero,
             halo_id_offset=0, halo_unique_id=0):
     """ Function generates a data table storing synthetic ultra-faint galaxies
     for purposes of extending the resolution limit of the simulation.

--- a/scripts/move_files.py
+++ b/scripts/move_files.py
@@ -1,0 +1,30 @@
+import sys
+import glob
+import os
+
+hpxdir = '/gpfs/mira-fs0/projects/DarkUniverse_esp/kovacs/OR_5000'
+hpxlist = 'hpx_z_0_empty.txt'
+base_dir = 'baseDC2_v0.1'
+new_dir = 'baseDC2_v0.1_empty'
+
+def read_list(fn):
+    with open(os.path.join(hpxdir, hpxlist), 'r') as fh:
+        contents = fh.read()
+        lines = contents.splitlines()
+
+    return lines
+
+def move_files(cutout_list, base_dir):
+    nmoved = 0
+    for hpx in cutout_list:
+        fn = os.path.join(hpxdir, base_dir,'*'+ hpx)
+        found_files = glob.glob(fn)
+        for f in found_files:
+            new_name = os.path.join(hpxdir, new_dir, os.path.basename(f))
+            os.rename(f, new_name)
+            nmoved += 1
+
+    print('Moved {} files to {}'.format(nmoved, new_dir))
+
+    moved_files = os.listdir(os.path.join(hpxdir, new_dir))
+    print('Total of {} files in {}'.format(len(moved_files), new_dir))


### PR DESCRIPTION
The integration warning from scipy was happening in the loop to add the required number of synthetics in the z=0 - 0.02 snapshot. I observed the code was running through many iterations of this loop because it was generating too few trial positions that survived the selection enforcing that the position be inside the healpixel. I also noticed that nan redshift values resulted. I added the following changes to the code to prevent the problem:
1) Set a lower limit of 3000 trial positions generated per loop iteration. Once the mask is applied, about 1 % survive the cut for the lowest z shell, and this is enough to satisfy the number of synthetics required in that shell.
2) Set the octant boundaries to small +ve and small -ve values for (x,y) and z directions to avoid generating a position exactly at (0., 0. 0.) ( would be a problem for redshift interpolation)
3) Set a minimum of 1e-10 for the grid used to interpolate redshift values from comoving distances
4) Added an assert statement to check that all interpolated redshifts are finite.
I have rerun a couple of healpixels to test the above changes and did not reproduce the problem.